### PR TITLE
Provide test to illustrate lookup table trickiness noted in issue #14

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,16 +6,18 @@ help:
 	@echo "Use make pypi to push to pypi."
 
 test:
-	py.test pyfinite --doctest-modules
+	py.test pyfinite tests --doctest-modules
 
 
 dist: pyfinite setup.py
 	python3 setup.py sdist
 
 test_pypi: README.rst dist
+	\rm -rf dist && ${MAKE} dist
 	twine upload --repository testpypi dist/*
 
 pypi: README.rst test dist
+	\rm -rf dist && ${MAKE} dist
 	twine upload --repository pypi dist/*
 
 README.rst: README.md

--- a/pyfinite/__init__.py
+++ b/pyfinite/__init__.py
@@ -1,4 +1,4 @@
 """Python package for finite field operations and erasure correction.
 """
 
-VERSION = '1.9'
+VERSION = '1.9.1'

--- a/pyfinite/ffield.py
+++ b/pyfinite/ffield.py
@@ -201,6 +201,16 @@ class FField:
         lutName = 'ffield.lut.' + repr(exponent)
         return lutName
 
+    def raise_on_bad_lut(self, lutName):
+        """Helper to complain if lookup table suspicious.
+        """
+        lut_gen = getattr(self.lut, 'generator', None)
+        if lut_gen != self.generator:
+            msg = (f'Refusing to use lookup table in file {lutName}.\n'
+                   'That file is for a different or unknown generator.\n'
+                   'Please remove that file or pass useLUT=0 to init.')
+            raise ValueError(msg)
+
     def PrepareLUT(self):
         fieldSize = 1 << self.n
         lutName = self.make_lut_path(self.n)
@@ -208,9 +218,10 @@ class FField:
             logging.info('Loading lookup table from %s', lutName)
             fd = open(lutName,'rb')
             self.lut = pickle.load(fd)
+            self.raise_on_bad_lut(lutName)
             fd.close()
         else:
-            self.lut = LUT()
+            self.lut = LUT(generator=self.generator, n=self.n)
             self.lut.mulLUT = list(range(fieldSize))
             self.lut.divLUT = list(range(fieldSize))
             self.lut.mulLUT[0] = [0]*fieldSize
@@ -486,10 +497,18 @@ class FField:
 
 
 class LUT:
+    """Lookup table used to speed up some finite field operations.
     """
-    Lookup table used to speed up some finite field operations.
-    """
-    pass
+
+    def __init__(self, generator, n):
+        """Initializer.
+
+        :param generator:   Generator for field we are making LUT for.
+
+        :param n:   Power size for field we are making LUT for.
+        """
+        self.generator = generator
+        self.n = n
 
 
 class FElement:

--- a/pyfinite/ffield.py
+++ b/pyfinite/ffield.py
@@ -26,6 +26,7 @@ detailed information on various topics:
 
 """
 
+import logging
 import string, random, os, os.path, pickle
 import sys
 import functools
@@ -193,12 +194,18 @@ class FField:
             self.Multiply = lambda a,b: self.DoMultiply(long(a),long(b))
             self.Divide = lambda a,b: self.DoDivide(long(a),long(b))
 
-
+    @staticmethod
+    def make_lut_path(exponent):
+        """Make path for lookup table.
+        """
+        lutName = 'ffield.lut.' + repr(exponent)
+        return lutName
 
     def PrepareLUT(self):
         fieldSize = 1 << self.n
-        lutName = 'ffield.lut.' + repr(self.n)
+        lutName = self.make_lut_path(self.n)
         if (os.path.exists(lutName)):
+            logging.info('Loading lookup table from %s', lutName)
             fd = open(lutName,'rb')
             self.lut = pickle.load(fd)
             fd.close()

--- a/pyfinite/test_basics.py
+++ b/pyfinite/test_basics.py
@@ -1,6 +1,7 @@
 """Some basic and quick unit tests.
 """
 
+import os
 import unittest
 import operator
 import types
@@ -18,6 +19,8 @@ Dividing by 0 should raise ZeroDivisionError and dividing 0 by something
 that is non-zero should return 0.
         """
         div_zero_throws = False
+        if os.path.exists(ffield.FField.make_lut_path(8)):
+            os.remove(ffield.FField.make_lut_path(8))
         my_field = ffield.FField(8, gen=355, useLUT=1)
         try:
             my_field.Divide(10, 0)

--- a/tests/lut_example.py
+++ b/tests/lut_example.py
@@ -1,0 +1,73 @@
+"""Simple examples of doctests to illustrate lookup table (LUT).
+
+You can run theses tests interactively in a python interpreter
+or you can do something like
+
+    python3 <PATH_TO_THIS_FILE>
+
+on the command line to test everything.
+
+To make sure we start from a clean environment, you will first
+want to make sure you delete any existing lookup tables.
+
+>>> import os
+>>> from pyfinite import ffield
+>>> lutName = ffield.FField.make_lut_path(8)
+>>> if os.path.exists(lutName):
+...     os.remove(lutName)
+...
+
+
+If you are trying to debug something, you may want to explicitly
+disable the lookup table by passing `useLUT=0` when creating a field.
+That will prevent you from using an old lookup table built from
+a different generator.  The following shows an example where we
+disable the lookup table:
+
+>>> from pyfinite import ffield
+>>> f_0x11B = ffield.FField(8, gen=0x11B, useLUT=0)
+>>> res = f_0x11B.Multiply(0xFF, 2) 
+>>> print(res)
+229
+
+Usually, lookup tables are built for small fields.
+
+>>> from pyfinite import ffield
+>>> f = ffield.FField(8)
+>>> print(f.generator)
+285
+>>> print(f.Multiply(0xFF, 2))
+227
+
+If you now create a field using a lookup table, you may get
+unexpected results:
+
+>>> from pyfinite import ffield
+>>> f_0x11B_with_LUT = ffield.FField(8, gen=0x11B)
+>>> res = f_0x11B_with_LUT.Multiply(0xFF, 2) 
+>>> print(res)
+227
+
+Another altrenative is to explicitly remove the lookup table
+if it exists to prevent this issue:
+
+>>> import os
+>>> from pyfinite import ffield
+>>> lutName = ffield.FField.make_lut_path(8)
+>>> if os.path.exists(lutName):
+...     os.remove(lutName)
+...
+>>> f_0x11B_with_LUT = ffield.FField(8, gen=0x11B)
+>>> res = f_0x11B_with_LUT.Multiply(0xFF, 2) 
+>>> print(res)
+229
+
+
+"""
+
+import doctest
+
+
+if __name__ == '__main__':
+    doctest.testmod()
+    print('Finished Tests')

--- a/tests/lut_example.py
+++ b/tests/lut_example.py
@@ -43,10 +43,15 @@ If you now create a field using a lookup table, you may get
 unexpected results:
 
 >>> from pyfinite import ffield
->>> f_0x11B_with_LUT = ffield.FField(8, gen=0x11B)
->>> res = f_0x11B_with_LUT.Multiply(0xFF, 2) 
->>> print(res)
-227
+>>> try:  # the following will raise an exception:
+...     f_0x11B_with_LUT = ffield.FField(8, gen=0x11B)
+... except ValueError as problem:
+...     print(problem)
+...
+Refusing to use lookup table in file ffield.lut.8.
+That file is for a different or unknown generator.
+Please remove that file or pass useLUT=0 to init.
+
 
 Another altrenative is to explicitly remove the lookup table
 if it exists to prevent this issue:


### PR DESCRIPTION
Provide test to illustrate lookup table trickiness noted in issue #14:

- lookup tables are automatically created for small fields to improve performance
- if you don't disable this feature and have lookup tables hanging around for other generators, you can get problems
- this PR provides a doctest in `tests/lut_example.py` to illustrate the issue
- feedback on how to make this clearer or change behavior is welcome